### PR TITLE
chore: add more golang format checkers

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -3,3 +3,11 @@ linters:
   enable:
     - whitespace
     - govet
+    - errcheck
+    - deadcode
+    - gosimple
+    - unused
+    - structcheck
+    - staticcheck
+    - typecheck
+    - varcheck


### PR DESCRIPTION
This pull request adds more `golang` style and format linters to enforce code style and format

Why ?
To enhance code quality it is important to add several additional checks for checking dead code, if the code is simple
and so on

How ?
To do that we edited the `.golangci.yml` file and added several checks 

Steps to verify:
When this PR is merged the additional checks will be performed on the `*.go` files