### PR TITLE
feat: add build-docker target

### DIFF
--- a/backend/.docker-env
+++ b/backend/.docker-env
@@ -1,0 +1,10 @@
+# API related configurations
+BASE_URI=api/
+PORT=9999
+
+# DATABASE related configurations
+PG_HOST=host.docker.internal
+PG_DBNAME=yotas
+PG_USER=yotas
+PG_PASSWORD=yotas
+PG_PORT=5432

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,18 +11,22 @@ COPY go.mod .
 COPY go.sum .
 RUN go mod download
 
+# copy yotas api code
 COPY . .
 
+# build the yotas api
 RUN go build -o api .
 
 WORKDIR /dist
 
 RUN cp /build/api .
 
+# build image with the binary
 FROM scratch
 
 COPY --from=builder /dist/api /
 
+# expose api port
 EXPOSE 9999
 
 ENTRYPOINT ["/api"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,28 @@
+FROM golang:alpine AS builder
+
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
+
+WORKDIR /build
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+
+RUN go build -o api .
+
+WORKDIR /dist
+
+RUN cp /build/api .
+
+FROM scratch
+
+COPY --from=builder /dist/api /
+
+EXPOSE 9999
+
+ENTRYPOINT ["/api"]

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -18,6 +18,10 @@ build:
 fmt:
 	go fmt ./...
 
+## build-docker: build docker image
+build-docker: test
+	docker build -t yotas-api .
+
 ## migrations
 install_goose:
 	go get -u github.com/pressly/goose/v3/cmd/goose


### PR DESCRIPTION
#### This pull request adds the build-docker target

**Why ?**
We would like to build api docker images

**How ?**

- [x] adds the `build-docker` target to the Makefile
- [x] add a `Dockerfile` to build the image
- [x] add a `.docker-env`   

**Steps to verify:**
Run `make build-docker` and see if it builds your docker image
To run the image run `docker run -p 9999:9999 --env-file .docker-env yotas-api`