### PR TITLE
Add docker compose

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -32,6 +32,13 @@ goose_up:
 goose_down:
 	cd migrations && goose postgres $(PG_STRING) down
 
+## start-postgres:
+start-postgres:
+	docker-compose up postgres
+
+## stop-postgres:
+stop-postgres:
+	docker-compose down
 
 ## vet: examines Go source code and reports suspicious constructs
 vet:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+
+services:
+  postgres:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_DB: yotas
+      POSTGRES_PASSWORD: yotas
+      POSTGRES_USER: yotas
+    ports:
+      - 5432:5432
+
+  api:
+    build: ./
+    depends_on:
+      - postgres
+    environment:
+      BASE_URI: api/
+      PORT: 9999
+      PG_HOST: postgres
+      PG_DBNAME: yotas
+      PG_USER: yotas
+      PG_PASSWORD: yotas
+      PG_PORT: 5432
+
+    ports:
+      - 9999:9999


### PR DESCRIPTION
#### This pull request setup a docker-compose to ease local development

**Why ?**
We need to provide a better local dev environment

**How ?**
Add a `docker-compose` file and add makefile targets to start and shut down `postgres`

**Steps to verify:**
Run `make start-postgres` once the DB has started run `make goose_up` then try to curl with `curl -H "Tenant: 1" localhost:9999/api/articles
{"data":[],"limit":1,"offset":0}` it should return a `200`

Note: depends on #65 and should be merged after its dependencies are merged