### PR TITLE
fix: change stretch image in favor of buster to fix libpq < 10

### DIFF
--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - postgres
     restart: always
-    image: golang:stretch
+    image: golang:buster
     command: /start-postgres/dev/scripts/wait-for-it/wait-for-it.sh postgres:5432 -t 120 -- /start-postgres/dev/setup-postgres/setup-postgres-and-run-api.sh
     env_file:
       - ./dev/setup-postgres/env

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   start-postgres:
     depends_on:
       - postgres
-    image: golang:stretch
+    image: golang:buster
     command: ["/start-postgres/dev/scripts/wait-for-it/wait-for-it.sh", "postgres:5432", "--", "/start-postgres/dev/setup-postgres/setup-postgres.sh"]
     volumes:
       - .:/start-postgres
@@ -24,7 +24,7 @@ services:
   api:
     depends_on:
       - start-postgres
-    image: golang:stretch
+    image: golang:buster
     command: ["/bin/bash", "-c", "cd /api/ && make run"]
     env_file:
       - ./dev/setup-postgres/env


### PR DESCRIPTION
#### This pull request changes `stretch` based images to `buster`

**Why ?**
The containers where not able to apply migrations correctly in postgres containers due, because the containers libpq were using a version < 10.
You can find out more on this pull request https://github.com/PostgREST/postgrest/issues/1443

**How ?**
It changes the `stretch` images to `buster` in the `docker-compose.yml` and `docker-compose.test.yml` files
As it is done in this pull request https://github.com/PostgREST/postgrest/pull/1467

**Steps to verify:**
Run `make docker-e2etest` if it runs without crashing it is alright