### PR TITLE
docs: Specifications for random articles list

### DIFF
--- a/docs/api/static/api/specs.yaml
+++ b/docs/api/static/api/specs.yaml
@@ -440,6 +440,30 @@ paths:
         "404":
           $ref: "#/components/responses/404Error"
 
+  /articles/random:
+    description: Random articles
+    get:
+      description: list 3 articles randomly from an random selected organisation
+      tags:
+        - Articles 
+      responses:
+        "200":
+          description: Successfull response
+          content:
+            application/json:
+              schema: 
+                type: "object"
+                properties:
+                  organisation: 
+                    type: "object"
+                    $ref: "#/components/schemas/Organisations"
+                  articles: 
+                    type: "array"
+                    items:
+                      type: "object"
+                      $ref: "#/components/schemas/Articles"
+
+
   /organisations/{organisationId}:
     get:
       tags:


### PR DESCRIPTION
#### This pull request does...

Add specification for the endpoint ``/articles/random``

This endpoint returns a list of 3 articles from a randomly selected organisation
